### PR TITLE
Switch off eslint rules that conflict with prettier default 

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,10 @@ _.eslintrc.json_
 
 ```json
 {
-	"extends": "./node_modules/@sofie-automation/code-standard-preset/eslint/main"
+	"extends": [
+        "./node_modules/@sofie-automation/code-standard-preset/eslint/main",
+        "prettier"
+    ]
 }
 ```
 

--- a/eslint/main.js
+++ b/eslint/main.js
@@ -1,5 +1,5 @@
 module.exports = {
-	extends: ['eslint:recommended', 'plugin:node/recommended', 'plugin:prettier/recommended'],
+	extends: ['eslint:recommended', 'plugin:node/recommended', 'plugin:prettier/recommended', 'prettier'],
 	plugins: ['prettier'],
 	rules: {
 		'prettier/prettier': 'error',

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
 		"@typescript-eslint/eslint-plugin": "^4.1.0",
 		"@typescript-eslint/parser": "^4.1.0",
 		"eslint": "^7.8.1",
-		"eslint-config-prettier": "^6.11.0",
+		"eslint-config-prettier": "^6.15.0",
 		"eslint-plugin-node": "^11.1.0",
 		"eslint-plugin-prettier": "^3.1.4",
 		"legally": "^3.5.8"

--- a/yarn.lock
+++ b/yarn.lock
@@ -681,10 +681,10 @@ escape-string-regexp@^1.0.5:
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
   integrity sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=
 
-eslint-config-prettier@^6.11.0:
-  version "6.11.0"
-  resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-6.11.0.tgz#f6d2238c1290d01c859a8b5c1f7d352a0b0da8b1"
-  integrity sha512-oB8cpLWSAjOVFEJhhyMZh6NOEOtBVziaqdDQ86+qhDHFbZXoRTM7pNSvFRfW/W/L/LrQ38C99J5CGuRBBzBsdA==
+eslint-config-prettier@^6.15.0:
+  version "6.15.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-6.15.0.tgz#7f93f6cb7d45a92f1537a70ecc06366e1ac6fed9"
+  integrity sha512-a1+kOYLR8wMGustcgAjdydMsQ2A/2ipRPwRKUmfYaSxc9ZPcrku080Ctl6zrZzZNs/U82MjSv+qKREkoq3bJaw==
   dependencies:
     get-stdin "^6.0.0"
 
@@ -2252,11 +2252,6 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
-
-typescript@~3.6.4:
-  version "3.6.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.6.5.tgz#dae20114a7b4ff4bd642db9c8c699f2953e8bbdb"
-  integrity sha512-BEjlc0Z06ORZKbtcxGrIvvwYs5hAnuo6TKdNFL55frVDlB+na3z5bsLhFaIxmT+dPWgBIjMo6aNnTOgHHmHgiQ==
 
 uglify-js@^3.1.4:
   version "3.10.4"


### PR DESCRIPTION
I've struggled a number of times with prettier fixing formatting and then eslint saying _no, no, no_, Ternary operators are a particular problem. 

The `eslint-prettier-config` was already included as a dependency, but not activated by rule extension.

For more background, see:

* https://github.com/prettier/prettier/issues/4199 (includes example of the problem)
* https://prettier.io/docs/en/integrating-with-linters.html#turn-off-eslint-s-formatting-rules
* https://github.com/prettier/eslint-config-prettier#excluding-deprecated-rules