### PR TITLE
fix: prettier eslint config

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ A script for checking compatible licenses is included.
     ...,
     "scripts": {
         ...,
-        "lint": "eslint . --ext .ts .js --ignore-pattern dist",
+        "lint": "eslint . --ext .ts --ext .js --ignore-pattern dist",
         "lint-fix": "yarn lint --fix",
         "license-validate": "yarn sofie-licensecheck -r --filter MIT --filter 0BSD --filter BSD --filter ISC --filter Apache --filter Unlicense --plain --border ascii"
     },

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ A script for checking compatible licenses is included.
     ...,
     "scripts": {
         ...,
-        "lint": "eslint . --ext .ts --ignore-pattern dist",
+        "lint": "eslint . --ext .ts .js --ignore-pattern dist",
         "lint-fix": "yarn lint --fix",
         "license-validate": "yarn sofie-licensecheck -r --filter MIT --filter 0BSD --filter BSD --filter ISC --filter Apache --filter Unlicense --plain --border ascii"
     },

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ _tsconfig.json_
 
 ```json
 {
-	"extends": "@sofie-automation/code-standard-preset/ts/tsconfig.lib",
+	"extends": "./tsconfig.build.json",
 	"exclude": ["node_modules/**"],
 	"compilerOptions": {
 		"types": ["jest", "node"]

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Sofie: The Modern TV News Studio Automation System (code standard preset)
 
-This library is used in the [**Sofie** TV News Studio Automation System](https://github.com/nrkno/Sofie-TV-automation/) for defining a code standard preset through [eslint](https://esling.org) and [prettier](https://prettier.io/). 
+This library is used in the [**Sofie** TV News Studio Automation System](https://github.com/nrkno/Sofie-TV-automation/) for defining a code standard preset through [eslint](https://esling.org) and [prettier](https://prettier.io/).
 
 A script for checking compatible licenses is included.
 
@@ -43,12 +43,12 @@ A script for checking compatible licenses is included.
 
 **Ensure** the following development dependencies are present:
 
-* `prettier`
-* `husky`
-* `lint-staged`
-* `@types\node` and `@types\jest` (if using)
-* Typescript 4 or above, e.g. `~4.0` with an up-to-date `ts-lib`
-* `jest` and `ts-jest`, if using
+- `prettier`
+- `husky`
+- `lint-staged`
+- `@types\node` and `@types\jest` (if using)
+- Typescript 4 or above, e.g. `~4.0` with an up-to-date `ts-lib`
+- `jest` and `ts-jest`, if using
 
 **Remove** any other linting configurations or linters. Also, `node-license-validator` is no longer required.
 
@@ -72,12 +72,9 @@ _tsconfig.json_
 {
 	"extends": "@sofie-automation/code-standard-preset/ts/tsconfig.lib",
 	"exclude": ["node_modules/**"],
-    "compilerOptions": {
-		"types": [
-			"jest",
-			"node"
-		]
-    }
+	"compilerOptions": {
+		"types": ["jest", "node"]
+	}
 }
 ```
 
@@ -94,7 +91,7 @@ _tsconfig.build.json_
 			"*": ["./node_modules/*"],
 			"{{PACKAGE-NAME}}": ["./src/index.ts"]
 		},
-		"types": ["node", "jest"]
+		"types": ["node"]
 	}
 }
 ```

--- a/eslint/main.js
+++ b/eslint/main.js
@@ -1,36 +1,38 @@
 module.exports = {
-	extends: ['eslint:recommended', 'plugin:node/recommended', 'plugin:prettier/recommended'],
-	plugins: ['prettier'],
+	extends: [
+		'eslint:recommended',
+		'plugin:@typescript-eslint/eslint-recommended',
+		'plugin:@typescript-eslint/recommended',
+		'plugin:node/recommended',
+		'prettier/@typescript-eslint',
+		'plugin:prettier/recommended',
+	],
+	plugins: ['@typescript-eslint', 'prettier'],
 	rules: {
 		'prettier/prettier': 'error',
 	},
 	env: { es2017: true },
 	parserOptions: { sourceType: 'module', ecmaVersion: 2018 },
 	overrides: [
+		// Note: these replace the values defined above, so make sure to extend them if they are needed
 		{
 			files: ['*.ts'],
 			parser: '@typescript-eslint/parser',
 			parserOptions: { project: './tsconfig.json' },
-			plugins: ['@typescript-eslint'],
-			extends: [
-				'eslint:recommended',
-				'plugin:@typescript-eslint/eslint-recommended',
-				'plugin:@typescript-eslint/recommended',
-				'prettier/@typescript-eslint',
-			],
 			settings: {
 				node: {
 					tryExtensions: ['.js', '.json', '.node', '.ts'],
 				},
 			},
 			rules: {
+				'prettier/prettier': 'error',
 				'no-unused-vars': 'off',
 				'no-extra-semi': 'off',
 				'@typescript-eslint/no-explicit-any': 'off',
 				'@typescript-eslint/interface-name-prefix': 'off',
 				'@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_' }],
 				'node/no-unsupported-features/es-syntax': ['error', { ignores: ['modules'] }],
-				"no-use-before-define": "off"
+				'no-use-before-define': 'off',
 			},
 		},
 		{
@@ -39,13 +41,16 @@ module.exports = {
 				jest: true,
 			},
 			rules: {
+				'prettier/prettier': 'error',
 				'@typescript-eslint/ban-ts-ignore': 'off',
-				"no-use-before-define": "off"
+				'@typescript-eslint/ban-ts-comment': 'off',
+				'no-use-before-define': 'off',
 			},
 		},
 		{
 			files: ['examples/**/*.ts'],
 			rules: {
+				'prettier/prettier': 'error',
 				'no-process-exit': 'off',
 				'node/no-missing-import': 'off',
 			},

--- a/eslint/main.js
+++ b/eslint/main.js
@@ -46,7 +46,7 @@ module.exports = {
 			},
 			rules: {
 				'prettier/prettier': 'error',
-				'no-unused-vars': 'off',
+				'no-unused-vars': ['error', { argsIgnorePattern: '^_' }],
 				'no-extra-semi': 'off',
 				'node/no-unsupported-features/es-syntax': ['error', { ignores: ['modules'] }],
 				'no-use-before-define': 'off',

--- a/eslint/main.js
+++ b/eslint/main.js
@@ -1,13 +1,6 @@
 module.exports = {
-	extends: [
-		'eslint:recommended',
-		'plugin:@typescript-eslint/eslint-recommended',
-		'plugin:@typescript-eslint/recommended',
-		'plugin:node/recommended',
-		'prettier/@typescript-eslint',
-		'plugin:prettier/recommended',
-	],
-	plugins: ['@typescript-eslint', 'prettier'],
+	extends: ['eslint:recommended', 'plugin:node/recommended', 'plugin:prettier/recommended'],
+	plugins: ['prettier'],
 	rules: {
 		'prettier/prettier': 'error',
 	},
@@ -17,6 +10,15 @@ module.exports = {
 		// Note: these replace the values defined above, so make sure to extend them if they are needed
 		{
 			files: ['*.ts'],
+			extends: [
+				'eslint:recommended',
+				'plugin:@typescript-eslint/eslint-recommended',
+				'plugin:@typescript-eslint/recommended',
+				'plugin:node/recommended',
+				'prettier/@typescript-eslint',
+				'plugin:prettier/recommended',
+			],
+			plugins: ['@typescript-eslint', 'prettier'],
 			parser: '@typescript-eslint/parser',
 			parserOptions: { project: './tsconfig.json' },
 			settings: {
@@ -31,6 +33,21 @@ module.exports = {
 				'@typescript-eslint/no-explicit-any': 'off',
 				'@typescript-eslint/interface-name-prefix': 'off',
 				'@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_' }],
+				'node/no-unsupported-features/es-syntax': ['error', { ignores: ['modules'] }],
+				'no-use-before-define': 'off',
+			},
+		},
+		{
+			files: ['*.js'],
+			settings: {
+				node: {
+					tryExtensions: ['.js', '.json', '.node', '.ts'],
+				},
+			},
+			rules: {
+				'prettier/prettier': 'error',
+				'no-unused-vars': 'off',
+				'no-extra-semi': 'off',
 				'node/no-unsupported-features/es-syntax': ['error', { ignores: ['modules'] }],
 				'no-use-before-define': 'off',
 			},


### PR DESCRIPTION
Alternate solution to #2

The 'overrides' block replaces values defined outside of it, so even though prettier was defined at the root level, that was being overridden for the `*.ts` rule, causing it to end up disabled.
By defining it in the local .eslintrc.json file, it was being forced to always be on.