### PR TITLE
disable the rule @typescript-eslint/ban-ts-comment

### DIFF
--- a/eslint/main.js
+++ b/eslint/main.js
@@ -33,6 +33,7 @@ module.exports = {
 				'@typescript-eslint/no-explicit-any': 'off',
 				'@typescript-eslint/interface-name-prefix': 'off',
 				'@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_' }],
+				'@typescript-eslint/ban-ts-comment': 'off',
 				'node/no-unsupported-features/es-syntax': ['error', { ignores: ['modules'] }],
 				'no-use-before-define': 'off',
 			},


### PR DESCRIPTION
I propose that we disable the `@typescript-eslint/ban-ts-comment` rule, as this creates extra work for us since we cannot use `// @ts-ignore` in our code.

While I do understand that the use of ts-ignore can be a problem long-term, I think that is does have a use case in our project.

(
It looks like devs are already trying to get around it, leading to these nuggets:
https://github.com/nrkno/tv-automation-playout-gateway/blob/release29/src/index.ts#L30
)