### PR TITLE
feat: add rule @typescript-eslint/no-floating-promises

### DIFF
--- a/eslint/main.js
+++ b/eslint/main.js
@@ -35,6 +35,7 @@ module.exports = {
 				'@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_' }],
 				'node/no-unsupported-features/es-syntax': ['error', { ignores: ['modules'] }],
 				'no-use-before-define': 'off',
+				'@typescript-eslint/no-floating-promises': 'error',
 			},
 		},
 		{


### PR DESCRIPTION
This PR adds the rule `@typescript-eslint/no-floating-promises`, I believe that we should enforce this rule in our repos, as that is a cause for Big Bad Bugs.

https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-floating-promises.md